### PR TITLE
Removed common items from toast

### DIFF
--- a/forge/src/main/java/com/affehund/invisibilitycloak/core/InvisibilityCloakDataGeneration.java
+++ b/forge/src/main/java/com/affehund/invisibilitycloak/core/InvisibilityCloakDataGeneration.java
@@ -61,9 +61,8 @@ public class InvisibilityCloakDataGeneration {
         @Override
         protected void buildCraftingRecipes(@Nonnull Consumer<FinishedRecipe> consumer) {
             ShapedRecipeBuilder.shaped(InvisibilityCloakForge.INVISIBILITY_CLOAK_ITEM.get()).pattern("fsf").pattern("ded").pattern("f f")
-                    .define('f', Items.FEATHER).unlockedBy("has_feather", has(Items.FEATHER)).define('s', Items.STRING).unlockedBy("has_string", has(Items.STRING)).define('d', Items.BLACK_DYE)
-                    .unlockedBy("has_black_dye", has(Items.BLACK_DYE)).define('e', Items.ELYTRA)
-                    .unlockedBy("has_elytra", has(Items.ELYTRA)).save(consumer);
+                    .define('f', Items.FEATHER).define('s', Items.STRING).define('d', Items.BLACK_DYE)
+                    .define('e', Items.ELYTRA).unlockedBy("has_elytra", has(Items.ELYTRA)).save(consumer);
         }
     }
 


### PR DESCRIPTION
The thing is, it is kind of mean to offer a invisibility cloak when the player just slew their first chicken. Recipe should be locked behind elytra. Matches vanilla better as well (you don't get the dia pick recipe after recieving a stick, for example)